### PR TITLE
Usability improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,15 +45,13 @@ For example: `/set_owner SomePlayer Mese city`
 3) You now own an area. You may now add sub-owners to it if you want to (see command `/add_owner`). Before using the `/add_owner` command you have to
 select the corners of the sub-area as you did in step 1.
 
-If your markers are still around your original area and you want to grant
-access to your entire area you will not have to re-set them. Use `/select_area` to place the markers at the corners of an existing area if you've reset your
-markers and want to grant access to a full area.
+If you want to add access to just a sub-area of the area, you can select a smaller area inside it. If you want to add access to the whole area, no selection is necessary; `/add_owner` will grant access to the whole area if you have no selection.
 
 The `/add_owner` command expects three arguments:
   1. The ID number of the parent area (the area that you want to add a
 	sub-area to).
   2. The name of the player that will own the sub-area.
-  3. The name of the sub-area. (can contain spaces)
+  3. The name of the sub-area (can contain spaces) - this is optional, if it is not included the existing area has its name re-used.
 
 For example: `/add_owner 123 BobTheBuilder Diamond lighthouse`
 
@@ -75,7 +73,7 @@ Commands
   * `/list_areas` -- Lists all of the areas that you own, or all areas if you
 	have the `areas` privilege.
 
-  * `/find_areas <Regex>` -- Finds areas using a Lua regular expresion.
+  * `/find_areas <Regex>` -- Finds areas using a Lua pattern.
 	For example, to find castles:
 
 		/find_areas [Cc]astle
@@ -101,6 +99,8 @@ Commands
 
   * `/area_pos2 [X,Y,Z|X Y Z]` -- Sets area position two to your position or
 	the one supplied.
+
+There are also aliases so that the word order is not important; `/add_owner` is the same as `/owner_add` for example.
 
 License
 -------

--- a/README.md
+++ b/README.md
@@ -58,12 +58,10 @@ For example: `/add_owner 123 BobTheBuilder Diamond lighthouse`
 
 Commands
 --------
+There are also aliases for most commands so that the word order is not important; `/add_owner` is the same as `/owner_add` for example.
 
   * `/protect <AreaName>` -- Protects an area for yourself. (if
 	self-protection is enabled)
-
-  * `/set_owner <OwnerName> <AreaName>` -- Protects an area for a specified
-	player. (requires the `areas` privilege)
 
   * `/add_owner <ParentID> <OwnerName> <ChildName>` -- Grants another player
 	control over part (or all) of an area.
@@ -71,12 +69,7 @@ Commands
   * `/rename_area <ID> <NewName>` -- Renames an existing area.
 
   * `/list_areas` -- Lists all of the areas that you own, or all areas if you
-	have the `areas` privilege.
-
-  * `/find_areas <Regex>` -- Finds areas using a Lua pattern.
-	For example, to find castles:
-
-		/find_areas [Cc]astle
+	have the `areas` privilege. Admins may also specify a specify a specific ID, range of ids or any player name.
 
   * `/remove_area <ID>` -- Removes an area that you own. Any sub-areas of that
 	area are made sub-areas of the removed area's parent, if it exists.
@@ -100,7 +93,21 @@ Commands
   * `/area_pos2 [X,Y,Z|X Y Z]` -- Sets area position two to your position or
 	the one supplied.
 
-There are also aliases so that the word order is not important; `/add_owner` is the same as `/owner_add` for example.
+### Admin-only Commands
+
+Apart from overriding all restrictions about ownership, admins also have some exclusive commands:
+
+  * `/find_areas <Regex>` -- Finds areas using a Lua pattern.
+	For example, to find castles:
+
+		/find_areas [Cc]astle
+
+  * `/list_areas_player` -- Lists the areas owned by a player. Only available to admins, otherwise for your areas use /list_areas.
+
+  * `/move_area` -- Move (or resize) an area to the current positions.
+
+  * `/set_owner <OwnerName> <AreaName>` -- Protects an area for a specified
+	player. (requires the `areas` privilege)
 
 License
 -------

--- a/pos.lua
+++ b/pos.lua
@@ -21,23 +21,29 @@ local function posLimit(pos)
 	}
 end
 
-minetest.register_chatcommand("select_area", {
+local function selectArea(name, param)
+	local id = tonumber(param)
+	if not id then
+		return false, S("Invalid usage, see /help @1.", "select_area")
+	end
+	if not areas.areas[id] then
+		return false, S("The area @1 does not exist.", id)
+	end
+
+	areas:setPos1(name, areas.areas[id].pos1)
+	areas:setPos2(name, areas.areas[id].pos2)
+	return true, S("Area @1 selected.", id)
+end
+
+local chatCommandParams = {
 	params = S("<ID>"),
 	description = S("Select an area by ID."),
-	func = function(name, param)
-		local id = tonumber(param)
-		if not id then
-			return false, S("Invalid usage, see /help @1.", "select_area")
-		end
-		if not areas.areas[id] then
-			return false, S("The area @1 does not exist.", id)
-		end
+	func = selectArea,
+}
 
-		areas:setPos1(name, areas.areas[id].pos1)
-		areas:setPos2(name, areas.areas[id].pos2)
-		return true, S("Area @1 selected.", id)
-	end,
-})
+minetest.register_chatcommand("select_area", chatCommandParams)
+minetest.register_chatcommand("area_select", chatCommandParams)
+
 
 minetest.register_chatcommand("area_pos1", {
 	params = "[X Y Z|X,Y,Z]",


### PR DESCRIPTION
* Aliases for most commands so word order isn't important.
* add_owner no longer requires a selection; if there is none, the whole area is shared. If no name is given, the existing area name is re-used.
* For admins, list_areas can list specific areas, area ranges with <start>-<fin>, or the areas of a player. New command list_areas player so admins can list their own areas and the areas of players with numbers as their name.
* Doc updates for all above.